### PR TITLE
Fixes crashes in development mode

### DIFF
--- a/src/containers/Builders/Template.js
+++ b/src/containers/Builders/Template.js
@@ -32,7 +32,7 @@ class Template extends Component {
     };
 ;
     render() {
-        let styles = { "background-color": this.props.current_user.colorvalue.stroke };
+        let styles = { "background-color": this.props.current_user.colorvalue ? this.props.current_user.colorvalue.stroke : "#FFFFFF" };
         return (
             <div className="template-container" style={styles}>
                 <div className="col-md-10 mx-auto">

--- a/src/containers/Scores/Scores.js
+++ b/src/containers/Scores/Scores.js
@@ -99,7 +99,7 @@ class Scores extends Component {
 
     setChart = () => {
         const {userScore, userTime, noOfQuestions, exercise} = this.props.location.state;
-        const {stroke, fill} = this.props.current_user.colorvalue;
+        const {stroke, fill} = this.props.current_user.colorvalue ? this.props.current_user.colorvalue : {stroke: "#00FFFF", fill: "#800080"};
 
         let score = Math.ceil(userScore / noOfQuestions * 100);
         let time = Math.ceil(userTime / 60);


### PR DESCRIPTION
Closes issue #6. The color value was not handled properly which was causing the react app to throw an error that cannot read property of undefined. According to the original developer, this app is not expected to function properly in development mode due to dependence on Sugarizer and Sugarizer Neighborhood data but I still think that result screen is a crucial functionality of the app and it should not break at the result screen even at the development mode.