### PR TITLE
Fixes the issue of displaying the result of same user multiple times

### DIFF
--- a/src/containers/Scores/Scores.js
+++ b/src/containers/Scores/Scores.js
@@ -93,6 +93,12 @@ class Scores extends Component {
 
     componentDidMount() {
         if (this.props.location) {
+            const {userScore, userTime, noOfQuestions, exercise} = this.props.location.state;
+            let score = Math.ceil(userScore / noOfQuestions * 100);
+            let time = Math.ceil(userTime / 60);
+            if (this.props.isShared) {
+                this.props.onSharedResult(exercise.id, score, time);
+            }
             this.setChart();
         }
     }
@@ -104,9 +110,6 @@ class Scores extends Component {
         let score = Math.ceil(userScore / noOfQuestions * 100);
         let time = Math.ceil(userTime / 60);
 
-        if (this.props.isShared) {
-            this.props.onSharedResult(exercise.id, score, time);
-        }
         const {name} = this.props.current_user;
 
         this.setState({


### PR DESCRIPTION
In the current state of the application if a user(In case of shared exercises) clicks on percentage or time chart icon in the results page, a copy its result is created again. This PR solves the issue.

Before:
![before](https://user-images.githubusercontent.com/34412933/54845599-cb23c000-4cff-11e9-9c03-dfa66484cb3f.png)


After:
![after_unique_result](https://user-images.githubusercontent.com/34412933/54845275-f8bc3980-4cfe-11e9-9809-4f1224fdb75f.png)
