### PR TITLE
fix: two clicks to validate mcq answers in evaluation mode

### DIFF
--- a/src/containers/Players/MCQPlayer.js
+++ b/src/containers/Players/MCQPlayer.js
@@ -160,6 +160,8 @@ class MCQPlayer extends Component {
 			currentScore: score,
 			userAnswers: updatedUserAnswers,
 		});
+
+		if(this.props.evaluationMode !== '') this.nextQuestion();
 	};
 
 	// move to next question


### PR DESCRIPTION
Fixes: #139 

[screen-recorder-thu-feb-23-2023-14-55-49.webm](https://user-images.githubusercontent.com/58461801/220869187-d8f3441e-32c2-4ab6-83db-6861d95138ff.webm)

